### PR TITLE
Update angular-metatags.js

### DIFF
--- a/angular-metatags-module/angular-metatags.js
+++ b/angular-metatags-module/angular-metatags.js
@@ -83,7 +83,7 @@ angular.module('metatags', [])
                 info[o] = otherwise[o];
             }
 
-            if (routeArgs[0] === pathArgs[0]) {
+            if (routeArgs[routeArgsLength - 1] === pathArgs[routeArgsLength - 1]) {
                 flag2 = true;
                 break;
             }


### PR DESCRIPTION
There was bug with URLs like:
/path/some1
/path/some2

/path/some2 was unreachable
