### PR TITLE
Add a bower file to fix this issue:

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,24 @@
+{
+  "name": "angular-metatags",
+  "version": "0.0.0",
+  "homepage": "https://github.com/AvraamMavridis/angular-metatags",
+  "authors": [
+    "Avraam Mavridis <avr.mav@gmail.com>"
+  ],
+  "description": "Module for providing dynamic Meta Tags to Angular routes",
+  "main": "./angular-metatags-module/angular-metatags.js",
+  "keywords": [
+    "angular",
+    "metatags",
+    "meta"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "app/bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
angular-metatags was not injected in your file.
Please go take a look in "/someapp/bower_components/angular-metatags" for the file you need, then manually include it in your file.
